### PR TITLE
Adjust pathes to ol scripts

### DIFF
--- a/index-mocha.html
+++ b/index-mocha.html
@@ -46,16 +46,16 @@
     <script src="../lib/jszip/dist/jszip.min.js"></script>
     <script src="../lib/geotiff.js/dist/geotiff.min.js"></script>
 
-    <link rel="stylesheet" type="text/css" href="../lib/ol3/ol.css">
-    <script src="../lib/ol3/ol.js"></script>
+    <link rel="stylesheet" type="text/css" href="../lib/ol3/css/ol.css">
+    <script src="../lib/ol3/build/ol.js"></script>
 
     <script src="../lib/jsonix/dist/Jsonix-all.js"></script>
 
     <!-- I figured these dependencies on my own, there must be a better way -->
-    <script src="../lib/ogc-schemas/Filter_1_0_0.js"></script>
+    <!--<script src="../lib/ogc-schemas/Filter_1_0_0.js"></script>
     <script src="../lib/ogc-schemas/GML_2_1_2.js"></script>
     <script src="../lib/ogc-schemas/SLD_1_0_0_GeoServer.js"></script>
-    <script src="../lib/ogc-schemas/XLink_1_0.js"></script>
+    <script src="../lib/ogc-schemas/XLink_1_0.js"></script>-->
 
     <script type="text/javascript">
         var Ext = Ext || {}; // Ext namespace won't be defined yet...

--- a/index-template.html
+++ b/index-template.html
@@ -35,16 +35,16 @@
     <script src="../lib/jszip/dist/jszip.min.js"></script>
     <script src="../lib/geotiff.js/dist/geotiff.min.js"></script>
 
-    <link rel="stylesheet" type="text/css" href="../lib/ol3/ol.css">
-    <script src="../lib/ol3/ol.js"></script>
+    <link rel="stylesheet" type="text/css" href="../lib/ol3/css/ol.css">
+    <script src="../lib/ol3/build/ol.js"></script>
 
     <script src="../lib/jsonix/dist/Jsonix-all.js"></script>
 
     <!-- I figured these dependencies on my own, there must be a better way -->
-    <script src="../lib/ogc-schemas/Filter_1_0_0.js"></script>
+    <!--<script src="../lib/ogc-schemas/Filter_1_0_0.js"></script>
     <script src="../lib/ogc-schemas/GML_2_1_2.js"></script>
     <script src="../lib/ogc-schemas/SLD_1_0_0_GeoServer.js"></script>
-    <script src="../lib/ogc-schemas/XLink_1_0.js"></script>
+    <script src="../lib/ogc-schemas/XLink_1_0.js"></script>-->
 
     <script type="text/javascript">
         var Ext = Ext || {}; // Ext namespace won't be defined yet...

--- a/index.html
+++ b/index.html
@@ -35,16 +35,16 @@
     <script src="../lib/jszip/dist/jszip.min.js"></script>
     <script src="../lib/geotiff.js/dist/geotiff.min.js"></script>
 
-    <link rel="stylesheet" type="text/css" href="../lib/ol3/ol.css">
-    <script src="../lib/ol3/ol.js"></script>
+    <link rel="stylesheet" type="text/css" href="../lib/ol3/css/ol.css">
+    <script src="../lib/ol3/build/ol.js"></script>
 
     <script src="../lib/jsonix/dist/Jsonix-all.js"></script>
 
     <!-- I figured these dependencies on my own, there must be a better way -->
-    <script src="../lib/ogc-schemas/Filter_1_0_0.js"></script>
+    <!--<script src="../lib/ogc-schemas/Filter_1_0_0.js"></script>
     <script src="../lib/ogc-schemas/GML_2_1_2.js"></script>
     <script src="../lib/ogc-schemas/SLD_1_0_0_GeoServer.js"></script>
-    <script src="../lib/ogc-schemas/XLink_1_0.js"></script>
+    <script src="../lib/ogc-schemas/XLink_1_0.js"></script>-->
 
     <script type="text/javascript">
         var Ext = Ext || {}; // Ext namespace won't be defined yet...


### PR DESCRIPTION
Adjusted local pathes to ol js and css files, removed (yet) not used ogc-schemas

Builded `ol.js` file can be created with the command `make check` inside of `lib/ol3` folder as described [here](https://github.com/openlayers/ol3/blob/master/CONTRIBUTING.md#the-check-build-target)

No review needed.
