### PR TITLE
Configurable layer tree in create mode

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -74,7 +74,7 @@
 
         "brace-style": [1, "1tbs"],
         "eol-last": 1,
-        "indent": 1,
+        "indent": [1, 4, { "SwitchCase": 1 }],
         "linebreak-style": [2, "unix"],
         "no-mixed-spaces-and-tabs": 2,
         "no-nested-ternary": 2,

--- a/app/Application.js
+++ b/app/Application.js
@@ -14,7 +14,8 @@ Ext.define('MoMo.admin.Application', {
         'ApplicationLayout',
         'AvailableModules',
         'Language',
-        'MapProjection'
+        'MapProjection',
+        'LayerTree'
     ],
 
     launch: function () {

--- a/app/model/Application.js
+++ b/app/model/Application.js
@@ -23,6 +23,9 @@ Ext.define('MoMo.admin.model.Application', {
         name: 'language',
         type: 'string'
     }, {
+        name: 'layerTree',
+        type: 'string'
+    }, {
         name: 'url',
         type: 'string',
         calculate: function (data) {

--- a/app/model/Base.js
+++ b/app/model/Base.js
@@ -9,8 +9,8 @@ Ext.define('MoMo.admin.model.Base', {
     ],
 
     fields: [{
-        name:'id',
-        type:'int',
+        name: 'id',
+        type: 'int',
         allowNull: true
     }],
 

--- a/app/model/LayerTreeNode.js
+++ b/app/model/LayerTreeNode.js
@@ -1,0 +1,62 @@
+Ext.define('MoMo.admin.model.LayerTreeNode', {
+    extend: 'Ext.data.TreeModel',
+    requires: [
+        'Ext.data.proxy.Rest',
+
+        'BasiGX.util.Url',
+        'BasiGX.util.CSRF',
+
+        'MoMo.admin.data.identifier.Null'
+    ],
+
+    proxy: {
+        type: 'rest',
+        url: BasiGX.util.Url.getWebProjectBaseUrl() + 'rest/layertree',
+        headers: BasiGX.util.CSRF.getHeader(),
+        reader: {
+            type: 'json',
+            transform: function(data) {
+                // this fixes an issue that occured
+                // when the drag'n'drop plugin was active, a folder was dropped
+                // and the store was synced afterwards (only changing the index)
+                if(data.leaf === false) {
+                    return [data];
+                }
+                return data;
+            }
+        }
+    },
+
+    idProperty: 'clientId',
+
+    fields: [{
+        name: 'clientId',
+        type: 'auto',
+        persist: false
+    }, {
+        name: 'id',
+        type: 'string',
+        allowNull: true
+    }, {
+        name: '@class',
+        type: 'string'
+    }, {
+        name: 'text',
+        type: 'string'
+    }, {
+        name: 'root',
+        type: 'boolean'
+    }, {
+        name: 'expanded',
+        type: 'boolean'
+    }, {
+        name: 'checked',
+        type: 'boolean'
+    }, {
+        name: 'index',
+        type: 'int',
+        defaultValue: -1,
+        persist: true
+    }]
+
+});

--- a/app/model/LayerTreeNode.js
+++ b/app/model/LayerTreeNode.js
@@ -4,9 +4,7 @@ Ext.define('MoMo.admin.model.LayerTreeNode', {
         'Ext.data.proxy.Rest',
 
         'BasiGX.util.Url',
-        'BasiGX.util.CSRF',
-
-        'MoMo.admin.data.identifier.Null'
+        'BasiGX.util.CSRF'
     ],
 
     proxy: {

--- a/app/store/LayerTree.js
+++ b/app/store/LayerTree.js
@@ -1,0 +1,32 @@
+Ext.define('MoMo.admin.store.LayerTree', {
+    extend: 'Ext.data.TreeStore',
+
+    storeId: 'momo-layertree',
+
+    model: 'MoMo.admin.model.LayerTreeNode',
+
+    autoLoad: false,
+
+    /**
+     * If syncRootNode is set to true, we'll sync the root node as well. Only
+     * useful if the corresponding override in
+     * admin/overrides/Ext.data.TreeStore.js is present.
+     */
+    syncRootNode: true,
+
+    listeners: {
+        write: function(store, operation) {
+            if (operation.getRequest().getAction() === 'create') {
+                var nextRec = store.getNewRecords()[0];
+
+                // If we're in create mode, the real parentId is not
+                // known in the client and we have to adjust it to the
+                // id returned by the backend. As we persist top down, the
+                // parentId should always be present here.
+                if (nextRec) {
+                    nextRec.set('parentId', nextRec.parentNode.get('id'));
+                }
+            }
+        }
+    }
+});

--- a/app/view/grid/ApplicationListController.js
+++ b/app/view/grid/ApplicationListController.js
@@ -45,23 +45,23 @@ Ext.define('MoMo.admin.view.grid.ApplicationListController', {
 
     handleCellClick: function(gridview, td, cellIndex, record){
         switch(cellIndex) {
-        case 2: // general-settings
-            Ext.toast("Edit general-settings");
-            break;
-        case 3: //tool-settings
-            Ext.toast("Edit tool-settings");
-            break;
-        case 4: //layer-settings
-            Ext.toast("Edit layer-settings");
-            break;
-        case 5: //share-settings
-            Ext.toast("Edit share-settings");
-            break;
-        case 6: // shwo preview
-            window.open('/momo/client?id=' + record.get('id'));
-            break;
-        default:
-            return;
+            case 2: // general-settings
+                Ext.toast("Edit general-settings");
+                break;
+            case 3: //tool-settings
+                Ext.toast("Edit tool-settings");
+                break;
+            case 4: //layer-settings
+                Ext.toast("Edit layer-settings");
+                break;
+            case 5: //share-settings
+                Ext.toast("Edit share-settings");
+                break;
+            case 6: // shwo preview
+                window.open('/momo/client?id=' + record.get('id'));
+                break;
+            default:
+                return;
         }
     }
 

--- a/app/view/grid/LayerListController.js
+++ b/app/view/grid/LayerListController.js
@@ -45,20 +45,20 @@ Ext.define('MoMo.admin.view.grid.LayerListController', {
 
     handleCellClick: function(gridview, td, cellIndex){
         switch(cellIndex) {
-        case 2:
-            Ext.toast("Edit general-settings");
-            break;
-        case 3:
-            Ext.toast("Edit style-settings");
-            break;
-        case 4:
-            Ext.toast("Download layerdata");
-            break;
-        case 5:
-            Ext.toast("Show Layer preview");
-            break;
-        default:
-            return;
+            case 2:
+                Ext.toast("Edit general-settings");
+                break;
+            case 3:
+                Ext.toast("Edit style-settings");
+                break;
+            case 4:
+                Ext.toast("Download layerdata");
+                break;
+            case 5:
+                Ext.toast("Show Layer preview");
+                break;
+            default:
+                return;
         }
     }
 

--- a/app/view/grid/LayerListController.js
+++ b/app/view/grid/LayerListController.js
@@ -6,6 +6,43 @@ Ext.define('MoMo.admin.view.grid.LayerListController', {
         // 'MoMo.admin.view.tab.CreateOrEditApplication'
     ],
 
+    /**
+     *
+     */
+    setComponentsVisibility: function(panel) {
+        var me = this;
+        var view = me.getView();
+
+        panel.down('button[name=create-layer-button]').setVisible(
+                view.getShowCreateButton());
+        panel.down('button[name=copy-layer-button]').setVisible(
+                view.getShowCopyButton());
+        panel.down('button[name=delete-layer-button]').setVisible(
+                view.getShowDeleteButton());
+        panel.down('textfield[name=filter-layer-list-field]').setVisible(
+                view.getShowFilterField());
+
+        Ext.each(panel.getColumns(), function(column) {
+            switch(column.name) {
+                case 'layer-settings-column':
+                    column.setVisible(view.getShowLayerSettingsColumn());
+                    break;
+                case 'layer-style-column':
+                    column.setVisible(view.getShowLayerStyleColumn());
+                    break;
+                case 'layer-metadata-column':
+                    column.setVisible(view.getShowLayerMetadataColumn());
+                    break;
+                case 'layer-preview-column':
+                    column.setVisible(view.getShowLayerPreviewColumn());
+                    break;
+                default:
+                    break;
+            }
+        });
+
+    },
+
     loadStore: function(){
         this.getView().getStore().load();
     },

--- a/app/view/grid/UserListController.js
+++ b/app/view/grid/UserListController.js
@@ -41,11 +41,11 @@ Ext.define('MoMo.admin.view.grid.UserListController', {
 
     handleCellClick: function(gridview, td, cellIndex){
         switch(cellIndex) {
-        case 2:
-            Ext.toast("Edit user-settings");
-            break;
-        default:
-            return;
+            case 2:
+                Ext.toast("Edit user-settings");
+                break;
+            default:
+                return;
         }
     }
 

--- a/app/view/panel/application/LayerModel.js
+++ b/app/view/panel/application/LayerModel.js
@@ -3,7 +3,8 @@ Ext.define('MoMo.admin.view.panel.application.LayerModel', {
     alias: 'viewmodel.momo-application-layer',
 
     data: {
-        title: 'Layer'
+        title: 'Layer',
+        availableLayersGridTitle: 'Available layers'
     }
 
 });

--- a/app/view/panel/application/StartViewController.js
+++ b/app/view/panel/application/StartViewController.js
@@ -135,17 +135,17 @@ Ext.define('MoMo.admin.view.panel.application.StartViewController', {
             mapView = map.getView();
 
         switch(field.getName()) {
-        case 'mapZoom':
-            mapView.setZoom(newVal);
-            break;
-        case 'mapCenterX':
-            mapView.setCenter([newVal, mapView.getCenter()[1]]);
-            break;
-        case 'mapCenterY':
-            mapView.setCenter([mapView.getCenter()[0], newVal]);
-            break;
-        default:
-            break;
+            case 'mapZoom':
+                mapView.setZoom(newVal);
+                break;
+            case 'mapCenterX':
+                mapView.setCenter([newVal, mapView.getCenter()[1]]);
+                break;
+            case 'mapCenterY':
+                mapView.setCenter([mapView.getCenter()[0], newVal]);
+                break;
+            default:
+                break;
         }
 
     },

--- a/app/view/tree/LayerTreeController.js
+++ b/app/view/tree/LayerTreeController.js
@@ -1,0 +1,456 @@
+Ext.define('MoMo.admin.view.grid.LayerTreeController', {
+    extend: 'Ext.app.ViewController',
+    alias: 'controller.momo-layertree',
+
+    requires: [
+        'Ext.menu.Menu',
+        'Ext.menu.Item'
+    ],
+
+    statics: {
+        LAYER_TREE_LEAF_CLASS: 'de.terrestris.momo.model.tree.LayerTreeLeaf',
+        LAYER_TREE_FOLDER_CLASS: 'de.terrestris.momo.model.tree.LayerTreeFolder'
+    },
+
+    /**
+     *
+     */
+    loadStoreData: function(panel) {
+        var me = this;
+        var view = me.getView();
+        var treeConfigId = view.getTreeConfigId();
+        var store = panel.getStore();
+
+        view.setLoading(true);
+
+        // We're in create mode
+        if (!treeConfigId) {
+            // We don't track any removed node in create mode, otherwise not
+            // yet persisted records are attempted to be deleted via REST
+            // TODO: I'm not sure if this solution is correct as soon as we've
+            // implemented the edit mode. It might be a problem then to have
+            // only one single store that will be reused in these two modes
+            store.setTrackRemoved(false);
+            me.requestAndSetDefaultRootNode();
+        } else {
+            store.setTrackRemoved(true);
+            // TODO: Set ID via view.setTreeConfigId() if we're in application
+            // edit mode otherwise we'll never reach this block
+            MoMo.admin.model.LayerTreeNode.load(treeConfigId, {
+                success: function(record) {
+                    store.setRoot(record);
+                    view.setLoading(false);
+                }
+            });
+        }
+    },
+
+    /**
+     *
+     */
+    syncTreeStore: function(cbFn, cbScope) {
+        var me = this;
+        var view = me.getView();
+        var store = view.getStore();
+
+        store.sync({
+            success: function(batch) {
+                var operations = batch.getOperations();
+                var treeConfigId;
+
+                // Iterate all operations and find the written root node record
+                Ext.each(operations, function(operation) {
+                    if (treeConfigId) {
+                        return false;
+                    }
+                    Ext.each(operation.getRecords(), function(record) {
+                        if (record.isRoot()) {
+                            treeConfigId = record.get('id');
+                            return false;
+                        }
+                    });
+                });
+
+                // TODO: reload store with id?
+                view.setTreeConfigId(treeConfigId);
+
+                cbFn.call(cbScope, [treeConfigId]);
+            }
+        });
+    },
+
+    /**
+     * Removes any existing context menu.
+     */
+    removeExistingContextMenus: function() {
+        var menus = Ext.ComponentQuery.query(
+                'menu[name=layer-tree-context-menu]');
+
+        Ext.each(menus, function(menu) {
+            menu.destroy();
+        });
+    },
+
+    /**
+     *
+     */
+    onItemContextMenu: function(view, rec, item, index, evt) {
+        var me = this;
+
+        // Prevent the standard browser context menu
+        evt.preventDefault();
+
+        me.removeExistingContextMenus();
+
+        var contextMenu = Ext.create(me.createItemContextMenuConf(rec));
+
+        contextMenu.showAt(evt.pageX, evt.pageY);
+    },
+
+    /**
+     *
+     */
+    onContainerContextMenu: function(view, evt) {
+        var me = this;
+
+        // Prevent the standard browser context menu
+        evt.preventDefault();
+
+        me.removeExistingContextMenus();
+
+        var contextMenu = Ext.create(me.createContainerContextMenuConf());
+
+        contextMenu.showAt(evt.pageX, evt.pageY);
+    },
+
+    /**
+     *
+     * @param {Ext.data.Model} record Clicked record
+     * @return contextMenuConf
+     */
+    createItemContextMenuConf: function(record) {
+        var me = this;
+        var viewModel = me.getViewModel();
+        var contextMenuConf;
+
+        contextMenuConf = {
+            xtype: 'menu',
+            plain: true,
+            name: 'layer-tree-context-menu',
+            record: record,
+            items: [{
+                xtype: 'menuitem',
+                bind: {
+                    text: viewModel.get('addTreeFolderMenuText')
+                },
+                handler: me.addTreeRecord,
+                hidden: record.get('leaf'),
+                scope: me
+            }, {
+                xtype: 'menuitem',
+                bind: {
+                    text: record.get('leaf') ?
+                            viewModel.get('deleteTreeLeafMenuText') :
+                            viewModel.get('deleteTreeFolderMenuText')
+                },
+                handler: me.deleteTreeRecord,
+                scope: me
+            }, {
+                xtype: 'menuitem',
+                bind: {
+                    text: record.get('leaf') ?
+                            viewModel.get('renameTreeLeafMenuText') :
+                            viewModel.get('renameTreeFolderMenuText')
+                },
+                handler: me.renameTreeRecord,
+                scope: me
+            }]
+        };
+
+        return contextMenuConf;
+    },
+
+    /**
+     *
+     */
+    createContainerContextMenuConf: function() {
+        var me = this;
+        var viewModel = me.getViewModel();
+        var contextMenuConf;
+
+        contextMenuConf = {
+            xtype: 'menu',
+            plain: true,
+            name: 'layer-tree-context-menu',
+            items: [{
+                xtype: 'menuitem',
+                bind: {
+                    text: viewModel.get('addTreeFolderTopLevelMenuText')
+                },
+                handler: me.addTreeRecord,
+                scope: me
+            }, {
+                xtype: 'menuitem',
+                bind: {
+                    text: viewModel.get('deleteAllTreeFoldersMenuText')
+                },
+                handler: me.deleteAllTreeRecords,
+                scope: me
+            }]
+        };
+
+        return contextMenuConf;
+    },
+
+    /**
+     *
+     */
+    addTreeRecord: function(item) {
+        var me = this;
+        var viewModel = me.getViewModel();
+        var record = item.up('menu').record || me.getView().getRootNode();
+
+        Ext.Msg.prompt(
+            viewModel.get('addTreeFolderWindowTitle'),
+            viewModel.get('addTreeFolderWindowMsg'),
+            function(btn, text) {
+                if (btn === 'ok' && !Ext.isEmpty(text)) {
+                    record.appendChild({
+                        '@class': me.self.LAYER_TREE_FOLDER_CLASS,
+                        text: text,
+                        leaf: false,
+                        checked: true,
+                        expandable: true
+                    });
+                }
+            }
+        );
+    },
+
+    /**
+     *
+     */
+    deleteTreeRecord: function(item) {
+        var me = this;
+        var viewModel = me.getViewModel();
+        var record = item.up('menu').record;
+
+        Ext.Msg.confirm(
+            record.get('leaf') ?
+                    viewModel.get('deleteTreeLeafWindowTitle') :
+                    viewModel.get('deleteTreeFolderWindowTitle'),
+            record.get('leaf') ?
+                    Ext.String.format(
+                            viewModel.get('deleteTreeLeafWindowMsg'),
+                            record.get('text')) :
+                    Ext.String.format(
+                            viewModel.get('deleteTreeFolderWindowMsg'),
+                            record.get('text')),
+            function (btn) {
+                if (btn === 'yes') {
+                    record.remove();
+                }
+            }
+        );
+    },
+
+    /**
+     *
+     */
+    renameTreeRecord: function(item) {
+        var me = this;
+        var viewModel = me.getViewModel();
+        var record = item.up('menu').record;
+
+        Ext.Msg.prompt(
+            record.get('leaf') ?
+                    viewModel.get('renameTreeLeafWindowTitle') :
+                        viewModel.get('renameTreeFolderWindowTitle'),
+            record.get('leaf') ?
+                    Ext.String.format(
+                            viewModel.get('renameTreeLeafWindowMsg'),
+                            record.get('text')) :
+                    Ext.String.format(
+                            viewModel.get('renameTreeFolderWindowMsg'),
+                            record.get('text')),
+            function(btn, text) {
+                if (btn === 'ok' && !Ext.isEmpty(text)) {
+                    record.set('text', text);
+                }
+            }
+        );
+    },
+
+    /**
+     *
+     */
+    deleteAllTreeRecords: function() {
+        var me = this;
+        var viewModel = me.getViewModel();
+        var rootNode = me.getView().getRootNode();
+
+        Ext.Msg.confirm(
+            viewModel.get('deleteAllTreeFoldersWindowText'),
+            viewModel.get('deleteAllTreeFoldersWindowMsg'),
+            function (btn) {
+                if (btn === 'yes') {
+                    rootNode.removeAll();
+                }
+            }
+        );
+    },
+
+    /**
+     *
+     */
+    requestAndSetDefaultRootNode: function() {
+        var me = this;
+        var view = me.getView();
+        var defaultLayerName = view.getDefaultTreeLayerName();
+
+        Ext.Ajax.request({
+            method: 'GET',
+            url: MoMo.admin.model.Layer.getProxy().getUrl() + '/filter',
+            params: {
+                name: defaultLayerName
+            },
+            success: me.onRequestDefaultLayerSuccess,
+            failure: me.onRequestDefaultLayerFailure,
+            scope: me
+        });
+    },
+
+    /**
+     *
+     */
+    onRequestDefaultLayerSuccess: function(response, conf) {
+        var me = this;
+        var view = me.getView();
+        var defaultLayer;
+
+        view.setLoading(false);
+
+        if (response && response.responseText) {
+            try {
+                defaultLayer = Ext.decode(arguments[0].responseText)[0];
+
+                if (!defaultLayer) {
+                    Ext.Logger.warn(Ext.String.format('Could not find the ' +
+                            'default layer named {0}. The default layer tree ' +
+                            'may not work as expected.', conf.params.name));
+                    return false;
+                }
+            } catch(err) {
+                Ext.Logger.error('Error while reading defaultLayer response: ',
+                        err);
+                return false;
+            }
+        }
+
+        var defaultLayerTreeNodeConf =
+            me.getDefaultLayerTreeNodeConfig(defaultLayer);
+
+        me.setDefaultLayerTreeNode(defaultLayerTreeNodeConf);
+    },
+
+    /**
+     *
+     */
+    onRequestDefaultLayerFailure: function(response) {
+        var errorMsg;
+
+        if (response && response.responseText) {
+            errorMsg = response.responseText;
+        }
+
+        Ext.Logger.error('Error while requesting defaultLayer response: ',
+                errorMsg);
+    },
+
+    /**
+     *
+     */
+    getDefaultLayerTreeNodeConfig: function(defaultLayer) {
+        var me = this;
+        var view = me.getView();
+        var clazz = me.self;
+
+        var defaultLayerTreeNodeConf = {
+            '@class': clazz.LAYER_TREE_FOLDER_CLASS,
+            index: 0,
+            root: true,
+            leaf: false,
+            // The root node should always checked, otherwise it wont be
+            // set as visible in the gis client context parser
+            checked: true,
+            expandable: true,
+            expanded: true,
+            children: [{
+                '@class': clazz.LAYER_TREE_FOLDER_CLASS,
+                text: view.getDefaultTreeFolderName(),
+                index: 1,
+                root: false,
+                leaf: false,
+                checked: true,
+                expandable: true,
+                expanded: true,
+                children: [{
+                    '@class': clazz.LAYER_TREE_LEAF_CLASS,
+                    text: defaultLayer.name,
+                    index: 0,
+                    leaf: true,
+                    checked: true,
+                    layer: defaultLayer.id
+                }]
+            }]
+        };
+
+        return defaultLayerTreeNodeConf;
+    },
+
+    /**
+     *
+     */
+    setDefaultLayerTreeNode: function(defaultLayerTreeNodeConf) {
+        var me = this;
+        var view = me.getView();
+        var store = view.getStore();
+        var layerTreeNode;
+
+        layerTreeNode = Ext.create('MoMo.admin.model.LayerTreeNode',
+                defaultLayerTreeNodeConf);
+
+        store.setRoot(layerTreeNode);
+    },
+
+    /**
+     *
+     */
+    onBeforeDrop: function(node, data, overModel, dropPosition, dropHandlers) {
+        var me = this;
+        var clazz = me.self;
+        var dropRecords = [];
+
+        Ext.each(data.records, function(record) {
+            if (!(record instanceof MoMo.admin.model.LayerTreeNode)) {
+                var treeRecord = Ext.create('MoMo.admin.model.LayerTreeNode', {
+                    '@class': clazz.LAYER_TREE_LEAF_CLASS,
+                    text: record.get('name'),
+                    index: 0,
+                    leaf: true,
+                    checked: false,
+                    layer: record.get('id')
+                });
+
+                dropRecords.push(treeRecord);
+            } else {
+                dropRecords.push(record);
+            }
+        });
+
+        data.records = dropRecords;
+
+        dropHandlers.processDrop();
+    }
+
+});

--- a/app/view/tree/LayerTreeModel.js
+++ b/app/view/tree/LayerTreeModel.js
@@ -1,0 +1,28 @@
+Ext.define('MoMo.admin.view.grid.LayerTreeModel', {
+    extend: 'Ext.app.ViewModel',
+    alias: 'viewmodel.momo-layertree',
+
+    data: {
+        title: 'Layertree',
+        addTreeFolderMenuText: 'Add folder (inside selected)',
+        addTreeFolderTopLevelMenuText: 'Add folder (top level)',
+        deleteTreeLeafMenuText: 'Delete leaf',
+        deleteTreeFolderMenuText: 'Delete folder',
+        deleteAllTreeFoldersMenuText: 'Delete tree contents completely',
+        renameTreeLeafMenuText: 'Rename leaf',
+        renameTreeFolderMenuText: 'Rename folder',
+        addTreeFolderWindowTitle: 'Add folder',
+        addTreeFolderWindowMsg:' Enter a name for the new folder',
+        deleteTreeLeafWindowTitle: 'Delete leaf',
+        deleteTreeFolderWindowTitle: 'Delete folder',
+        deleteTreeLeafWindowMsg: 'Do you really want to delete leaf {0}?',
+        deleteTreeFolderWindowMsg: 'Do you really want to delete folder {0}?',
+        deleteAllTreeFoldersWindowText: 'Delete tree contents completely',
+        deleteAllTreeFoldersWindowMsg: 'Do you really want to delete the ' +
+                'tree contents completely?',
+        renameTreeLeafWindowTitle: 'Rename leaf',
+        renameTreeFolderWindowTitle: 'Rename folder',
+        renameTreeLeafWindowMsg: 'Enter a new name for the leaf {0}',
+        renameTreeFolderWindowMsg: 'Enter a new name for the folder {0}'
+    }
+});

--- a/classic/src/view/grid/LayerList.js
+++ b/classic/src/view/grid/LayerList.js
@@ -20,11 +20,26 @@ Ext.define('MoMo.admin.view.grid.LayerList',{
         type: 'layers'
     },
 
+    config: {
+        showCreateButton: true,
+        showCopyButton: true,
+        showDeleteButton: true,
+        showFilterField: true,
+        showLayerSettingsColumn: true,
+        showLayerStyleColumn: true,
+        showLayerMetadataColumn: true,
+        showLayerPreviewColumn: true
+    },
+
     bind: {
         title: '{title}'
     },
 
     hideHeaders: true,
+
+    listeners: {
+        beforerender: 'setComponentsVisibility'
+    },
 
     selModel: {
         type: 'checkboxmodel',
@@ -47,18 +62,21 @@ Ext.define('MoMo.admin.view.grid.LayerList',{
         tpl: '<div data-qtip="{name}">{name}</div>'
     },{
         xtype: 'templatecolumn',
+        name: 'layer-settings-column',
         width: 40,
         align: "center",
         tdCls: "column-tool",
         tpl: '<i class="fa fa-gear fa-2x" data-qtip="Layer Settings">'
     },{
         xtype: 'templatecolumn',
+        name: 'layer-style-column',
         width: 40,
         align: "center",
         tdCls: "column-tool",
         tpl: '<i class="fa fa-paint-brush fa-2x" data-qtip="Layer Style"></i>'
     },{
         xtype: 'templatecolumn',
+        name: 'layer-metadata-column',
         width: 40,
         align: "center",
         tdCls: "column-tool",
@@ -66,6 +84,7 @@ Ext.define('MoMo.admin.view.grid.LayerList',{
                 'data-qtip="Download Layerdata"></i>'
     },{
         xtype: 'templatecolumn',
+        name: 'layer-preview-column',
         width: 40,
         align: "center",
         tdCls: "column-tool",
@@ -74,6 +93,7 @@ Ext.define('MoMo.admin.view.grid.LayerList',{
 
     tbar: [{
         xtype: 'button',
+        name: 'create-layer-button',
         text: 'Create',
         scale: 'large',
         ui: 'momo',
@@ -81,6 +101,7 @@ Ext.define('MoMo.admin.view.grid.LayerList',{
         handler: 'onCreateClick'
     }, {
         xtype: 'button',
+        name: 'copy-layer-button',
         text: 'Copy',
         scale: 'large',
         ui: 'momo',
@@ -88,6 +109,7 @@ Ext.define('MoMo.admin.view.grid.LayerList',{
         handler: 'onCopyClick'
     }, {
         xtype: 'button',
+        name: 'delete-layer-button',
         text: 'Delete',
         scale: 'large',
         ui: 'momo',
@@ -95,6 +117,7 @@ Ext.define('MoMo.admin.view.grid.LayerList',{
         handler: 'onDeleteClick'
     }, '->', {
         xtype: 'textfield',
+        name: 'filter-layer-list-field',
         fieldLabel: 'Filter by name',
         labelWidth: undefined,
         triggers: {

--- a/classic/src/view/panel/application/General.js
+++ b/classic/src/view/panel/application/General.js
@@ -23,6 +23,8 @@ Ext.define('MoMo.admin.view.panel.application.General', {
 
     padding: 20,
 
+    scrollable: 'y',
+
     items: [{
         xtype: 'fieldset',
         bind: {

--- a/classic/src/view/panel/application/Layer.js
+++ b/classic/src/view/panel/application/Layer.js
@@ -5,7 +5,9 @@ Ext.define('MoMo.admin.view.panel.application.Layer', {
 
     requires: [
         'MoMo.admin.view.panel.application.LayerController',
-        'MoMo.admin.view.panel.application.LayerModel'
+        'MoMo.admin.view.panel.application.LayerModel',
+
+        'MoMo.admin.view.tree.LayerTree'
     ],
 
     controller: 'momo-application-layer',
@@ -22,18 +24,47 @@ Ext.define('MoMo.admin.view.panel.application.Layer', {
 
     padding: 20,
 
+    layout: 'fit',
+
     items: [{
         xtype: 'fieldset',
         bind: {
             title: '{title}'
         },
-        defaults: {
-            width: '100%',
-            msgTarget: 'side'
+        layout: {
+            type: 'hbox',
+            align: 'stretch'
         },
         items: [{
-            xtype: 'gridpanel',
-            title: 'Available layers'
+            xtype: 'momo-layerlist',
+            scrollable: 'y',
+            flex: 1,
+            bind: {
+                title: '{availableLayersGridTitle}'
+            },
+            viewConfig: {
+                plugins: {
+                    ptype: 'gridviewdragdrop',
+                    ddGroup: 'layertree-dd-group',
+                    enableDrop: false
+                }
+            },
+            selModel: {
+                selType: 'rowmodel',
+                mode: 'MULTI'
+            },
+            showCreateButton: false,
+            showCopyButton: false,
+            showDeleteButton: false,
+            showLayerSettingsColumn: false,
+            showLayerStyleColumn: false
+        }, {
+            xtype: 'displayfield',
+            width: 15
+        }, {
+            xtype: 'momo-layertree',
+            scrollable: 'y',
+            flex: 1
         }]
     }]
 

--- a/classic/src/view/panel/application/StartView.js
+++ b/classic/src/view/panel/application/StartView.js
@@ -25,11 +25,16 @@ Ext.define('MoMo.admin.view.panel.application.StartView', {
 
     padding: 20,
 
+    layout: 'fit',
+
     items: [{
         xtype: 'fieldset',
-        autoScroll: true,
         bind: {
             title: '{title}'
+        },
+        layout: {
+            type: 'vbox',
+            align: 'stretch'
         },
         defaults: {
             width: '100%'
@@ -164,7 +169,7 @@ Ext.define('MoMo.admin.view.panel.application.StartView', {
             }]
         }, {
             xtype: 'gx_map',
-            height: 500,
+            flex: 1,
             listeners: {
                 render: 'renderMap',
                 boxready: 'addMapCrossHair'

--- a/classic/src/view/tab/CreateOrEditApplication.js
+++ b/classic/src/view/tab/CreateOrEditApplication.js
@@ -51,8 +51,7 @@ Ext.define('MoMo.admin.view.tab.CreateOrEditApplication', {
     }, {
         xtype: 'momo-application-start-view'
     }, {
-        xtype: 'momo-application-layer',
-        disabled: true
+        xtype: 'momo-application-layer'
     }]
 
 });

--- a/classic/src/view/tree/LayerTree.js
+++ b/classic/src/view/tree/LayerTree.js
@@ -1,0 +1,68 @@
+Ext.define('MoMo.admin.view.tree.LayerTree',{
+    extend: 'Ext.tree.Panel',
+
+    xtype: 'momo-layertree',
+
+    requires: [
+        'MoMo.admin.view.grid.LayerTreeController',
+        'MoMo.admin.view.grid.LayerTreeModel',
+
+        'MoMo.admin.store.LayerTree'
+    ],
+
+    controller: 'momo-layertree',
+
+    viewModel: {
+        type: 'momo-layertree'
+    },
+
+    store: 'momo-layertree',
+
+    bind: {
+        title: '{title}'
+    },
+
+    viewConfig: {
+        plugins: {
+            ptype: 'treeviewdragdrop',
+            ddGroup: 'layertree-dd-group',
+            allowContainerDrops: true,
+            containerScroll: true
+        }
+    },
+
+    config: {
+        /**
+         * The ID of the current layertree. Only useful if we're in edit mode.
+         */
+        treeConfigId: null,
+
+        /**
+         * The default treefolder name if we're in create mode.
+         */
+        defaultTreeFolderName: 'Hintergrundlayer',
+
+        /**
+         * The name (this is the name of the de.terrestris.momo.model.MomoLayer
+         * entity) of the default layer if we're in create mode.
+         */
+        defaultTreeLayerName: 'OSM-WMS GRAY'
+    },
+
+    rootVisible: false,
+
+    hideHeaders: true,
+
+    selModel: {
+        selType: 'rowmodel',
+        mode: 'MULTI'
+    },
+
+    listeners: {
+        afterrender: 'loadStoreData',
+        itemcontextmenu: 'onItemContextMenu',
+        containercontextmenu: 'onContainerContextMenu',
+        beforedrop: 'onBeforeDrop'
+    }
+
+});

--- a/classic/src/view/viewport/Viewport.js
+++ b/classic/src/view/viewport/Viewport.js
@@ -72,7 +72,6 @@ Ext.define('MoMo.admin.view.viewport.Viewport', {
         }]
     }, {
         xtype: 'momo-maincontainerwrap',
-        id: 'main-view-detail-wrap',
         reference: 'mainContainerWrap',
         flex: 1,
         items: [{
@@ -105,8 +104,7 @@ Ext.define('MoMo.admin.view.viewport.Viewport', {
             cls: 'main-card-panel',
             itemId: 'contentPanel',
             layout: {
-                type: 'card',
-                anchor: '100%'
+                type: 'card'
             }
         }]
     }]

--- a/overrides/Ext.data.TreeStore.js
+++ b/overrides/Ext.data.TreeStore.js
@@ -1,0 +1,16 @@
+Ext.define('MoMo.overrides.Ext.data.TreeStore', {
+    override: 'Ext.data.TreeStore',
+    requires: [
+        'Ext.data.TreeStore'
+    ],
+
+    /**
+     * If syncRootNode is set to true, we'll sync the root node as well.
+     */
+    syncRootNode: false,
+
+    filterNew: function(item) {
+        return (this.syncRootNode || !item.get('root')) &&
+                Ext.data.TreeStore.superclass.filterNew.apply(this, arguments);
+    }
+});

--- a/overrides/Ext.data.proxy.Rest.js
+++ b/overrides/Ext.data.proxy.Rest.js
@@ -1,0 +1,54 @@
+Ext.define('MoMo.overrides.Ext.data.proxy.Rest', {
+    override: 'Ext.data.proxy.Rest',
+    requires: [
+        'Ext.data.proxy.Rest'
+    ],
+
+    buildUrl: function(request) {
+        var me = this,
+            operation = request.getOperation(),
+            records = operation.getRecords(),
+            record = records ? records[0] : null,
+            format = me.getFormat(),
+            url = me.getUrl(request),
+            id,
+            params;
+
+        if (record && !record.phantom) {
+            id = record.getId();
+        } else {
+            id = operation.getId();
+        }
+
+        // Remove root from the URL
+        if (id === 'root') {
+            id = '';
+        }
+
+        if (me.getAppendId() && me.isValidId(id)) {
+            if (!url.match(me.slashRe)) {
+                url += '/';
+            }
+
+            url += encodeURIComponent(id);
+            params = request.getParams();
+            if (params) {
+                delete params[me.getIdParam()];
+            }
+        }
+
+        if (format) {
+            if (!url.match(me.periodRe)) {
+                url += '.';
+            }
+
+            url += format;
+        }
+
+        request.setUrl(url);
+
+        // … but remember to call the superclass buildUrl so that additional
+        // parameters like the cache buster string are appended.
+        return Ext.data.proxy.Rest.superclass.buildUrl.apply(this, arguments);
+    }
+});


### PR DESCRIPTION
Enables the `Layer` panel in the application-create mode to configure the layer tree for the application and to persist this configuration via REST.

Related PRs: 
* https://github.com/terrestris/momo3-frontend/pull/44
* https://github.com/terrestris/momo3-backend/pull/46