### PR TITLE
Disable row in layergrid if READ permission is only granted from application

### DIFF
--- a/app/model/Layer.js
+++ b/app/model/Layer.js
@@ -39,6 +39,9 @@ Ext.define('MoMo.admin.model.Layer', {
             type: 'LayerAppearance',
             unique: true
         }
+    }, {
+        name: 'readPermissionGrantedFromAnyApplication',
+        type: 'boolean'
     }]
 
     // manyToMany: {

--- a/classic/src/view/grid/LayerList.js
+++ b/classic/src/view/grid/LayerList.js
@@ -21,7 +21,23 @@ Ext.define('MoMo.admin.view.grid.LayerList',{
         sorters: [{
             property: 'name',
             direction: 'ASC'
-        }]
+        }],
+        listeners: {
+            load: function(store){
+                var layerList = Ext.ComponentQuery.query('momo-layerlist')[0];
+                var tableView = layerList.getView();
+                store.each(function(rec) {
+                    if (rec.get('readPermissionGrantedFromAnyApplication')) {
+                        var row = tableView.getRow(rec);
+                        if (row) {
+                            var el = Ext.fly(row);
+                            // mask the user row
+                            el.mask();
+                        }
+                    }
+                });
+            }
+        }
     },
 
     config: {


### PR DESCRIPTION
Title says it all, depends on new property `readPermissionGrantedFromAnyApplication`, see also https://github.com/terrestris/momo3-backend/pull/87