### PR TITLE
Configurable legend graphic (#4352)

### DIFF
--- a/app/model/Layer.js
+++ b/app/model/Layer.js
@@ -25,6 +25,9 @@ Ext.define('MoMo.admin.model.Layer', {
         name: 'dataType',
         type: 'string'
     }, {
+        name: 'fixLegendUrl',
+        type: 'string'
+    }, {
         name: 'sourceId',
         reference: {
             type: 'LayerSource',

--- a/app/view/tab/CreateOrEditLayerModel.js
+++ b/app/view/tab/CreateOrEditLayerModel.js
@@ -24,7 +24,12 @@ Ext.define('MoMo.admin.view.tab.CreateOrEditLayerModel', {
                 layerDescription: 'Layer Description',
                 layerOpacity: 'Layer Opacity',
                 hoverTemplate: 'Hover Template',
-                availableAttributes: 'Available Attributes'
+                availableAttributes: 'Available Attributes',
+                legend: {
+                    title: 'Legend settings',
+                    useFixLegendUrlCbBoxLabel: 'Fix legend image (instead of GetLegendGraphic)?',
+                    chooseOrUploadImage: 'Upload/choose image'
+                }
             },
             metadata: {
                 title: 'Titel',
@@ -168,6 +173,11 @@ Ext.define('MoMo.admin.view.tab.CreateOrEditLayerModel', {
                 return get('upload.vector.hasPrj');
             } else {
                 return false;
+            }
+        },
+        hasFixLegendUrl: {
+            get: function(get) {
+                return !Ext.isEmpty(get('layer.fixLegendUrl'));
             }
         }
     }

--- a/classic/src/view/panel/layer/General.js
+++ b/classic/src/view/panel/layer/General.js
@@ -31,11 +31,13 @@ Ext.define('MoMo.admin.view.panel.layer.General',{
         bind: {
             title: '{i18n.general.generalTitle}'
         },
-        layout: 'column',
+        layout: 'form',
         scrollable: 'y',
         items: [{
             xtype: 'fieldcontainer',
-            columnWidth: 0.5,
+            defaults: {
+                labelWidth: 130
+            },
             items: [{
                 xtype: 'displayfield',
                 bind: {
@@ -198,6 +200,7 @@ Ext.define('MoMo.admin.view.panel.layer.General',{
                     increment: 0.01,
                     decimalPrecision: 2,
                     submitValue: false,
+                    labelWidth: 130,
                     bind:{
                         fieldLabel: '{i18n.general.layerOpacity}',
                         value: '{layer.appearance.opacity}',
@@ -230,7 +233,7 @@ Ext.define('MoMo.admin.view.panel.layer.General',{
                     width: 400,
                     name: 'layerHoverTemplate',
                     margin: '0 5px 0 0',
-                    flex: 1,
+                    labelWidth: 130,
                     bind: {
                         fieldLabel: '{i18n.general.hoverTemplate}',
                         value: '{layer.appearance.hoverTemplate}'
@@ -242,10 +245,53 @@ Ext.define('MoMo.admin.view.panel.layer.General',{
                     },
                     handler: 'onAttributesButtonClicked'
                 }]
+            }, {
+                xtype: 'fieldset',
+                name: 'legendFieldset',
+                bind: {
+                    title: '{i18n.general.legend.title}'
+                },
+                scrollable: 'y',
+                defaults: {
+                    layout: 'vbox',
+                    align: 'stretchmax',
+                    margin: 5
+                },
+                items: [{
+                    xtype: 'container',
+                    items: [{
+                        xtype: 'checkbox',
+                        width: 350,
+                        bind: {
+                            boxLabel: '{i18n.general.legend.useFixLegendUrlCbBoxLabel}',
+                            value: '{hasFixLegendUrl}'
+                        },
+                        listeners: {
+                            change: 'onHasFixLegendCbChange'
+                        }
+                    }, {
+                        xtype: 'button',
+                        name: 'graphic-pool-btn',
+                        handler: 'onChooseImageClick',
+                        bind: {
+                            text: '{i18n.general.legend.chooseOrUploadImage}',
+                            disabled: '{!hasFixLegendUrl}'
+                        }
+                    }, {
+                        xtype: 'image',
+                        name: 'legend-img-preview',
+                        bind: {
+                            src: '{layer.fixLegendUrl}'
+                        },
+                        listeners : {
+                            load : {
+                                element : 'el',
+                                fn : 'onLegendImageLoad'
+                            }
+                        }
+                    }]
+                }]
             }]
-        },{
-            xtype: 'container',
-            columnWidth: 0.5
         }]
     }]
 });

--- a/classic/src/view/panel/layer/General.js
+++ b/classic/src/view/panel/layer/General.js
@@ -39,7 +39,9 @@ Ext.define('MoMo.admin.view.panel.layer.General',{
             items: [{
                 xtype: 'displayfield',
                 bind: {
-                    value: '{i18n.general.uploadDescription}'
+                    value: '{i18n.general.uploadDescription}',
+                    // show for createLayer only
+                    hidden: '{!isNewLayer}'
                 }
             }, {
                 xtype: 'textfield',


### PR DESCRIPTION
Frontend part for configurable layer legend graphic in admin application.

If config is checked, user has the possibillity to upload his own image to be used instead of default legendGraphic image generated from SLD assigned to layer.

Depends on https://github.com/terrestris/momo3-backend/pull/131

Please review @weskamm